### PR TITLE
Add OP-1F tape export feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "digichain",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "digichain",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "devDependencies": {
         "@rollup/plugin-terser": "^0.4.3",
         "csso": "^5.0.5",
@@ -615,6 +615,7 @@
       "integrity": "sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },

--- a/src/index.html
+++ b/src/index.html
@@ -288,6 +288,43 @@
     <div id="mergePanelContent"></div>
 </dialog>
 
+<dialog id="op1fTapeExportPanel" class="dialog-pop-up">
+    <a class="float-right sticky-top-0" onpointerdown="document.getElementById('op1fTapeExportPanel').close();"><i class="gg-close"></i></a>
+    <div class="content">
+        <h3>OP-1F Tape Export</h3>
+        <div class="op1f-help-text">
+            <p>With this functionality, you can export the selected samples to an OP-1F track. The slice information will be exported in a separate tape.json file. If you are creating an OP-1F tape from scratch, you can put the samples on any track. If you are exporting the samples into an existing tape, you need to upload the existing tape.json file first. It is recommended that you export the samples to a track with no existing content. The export process removes the existing clip information from the selected track.</p>
+        </div>
+        <div class="op1f-tape-mode-section">
+            <label class="op1f-radio-label">
+                <input type="radio" name="tapeMode" value="new" checked onchange="digichain.updateOp1fTapeMode('new')">
+                Create new tape.json
+            </label>
+            <label class="op1f-radio-label">
+                <input type="radio" name="tapeMode" value="load" onchange="digichain.updateOp1fTapeMode('load')">
+                Load existing tape.json
+            </label>
+            <div id="tapeJsonLoadContainer" class="op1f-file-input-section">
+                <label for="tapeJsonFileInput" class="op1f-file-label">Select tape.json file:</label>
+                <input id="tapeJsonFileInput" type="file" accept=".json">
+            </div>
+        </div>
+        <div class="op1f-track-section">
+            <label for="op1fTrackSelect" class="op1f-track-label">Export to track:</label>
+            <select id="op1fTrackSelect">
+                <option value="0">Track 1</option>
+                <option value="1">Track 2</option>
+                <option value="2">Track 3</option>
+                <option value="3">Track 4</option>
+            </select>
+        </div>
+        <div class="op1f-button-group">
+            <button onpointerdown="document.getElementById('op1fTapeExportPanel').close();" class="button-outline">Cancel</button>
+            <button onpointerdown="digichain.configureOp1fTapeExport(event)" class="button">OK</button>
+        </div>
+    </div>
+</dialog>
+
 <div class="pop-up-blind"></div>
 
 <div class="header-menu">
@@ -529,6 +566,8 @@
                                 onclick="digichain.updateExportChainsAsPresets({device: 'tv', length: 84})" class="toggle-preset-bundling-tv button-clear">TV</button>
                         <button title="OP-XY Preset bundling, chains will be limited to 24, samples longer than 20 seconds will be truncated to allow playback on the Xy (be mindful that the XY has a total 64mb of memory per project loaded for samples). When active, only zip downloads will be available."
                                 onclick="digichain.updateExportChainsAsPresets({device: 'xy', length: 24})" class="toggle-preset-bundling-xy button-clear">XY</button>
+                        <button title="Export the files as an OP-1F tape track. When active, only zip downloads will be available."
+                                onclick="digichain.toggleOp1fMode(event)" class="toggle-preset-bundling-op1f button-clear">OP-1F</button>
                     </div>
                 </div>
                 <a id="getJoined">_</a>

--- a/src/main.css
+++ b/src/main.css
@@ -2288,6 +2288,72 @@ dialog .content {
     background-color: inherit;
 }
 
+/* OP-1F Tape Export Dialog Styles */
+.op1f-help-text {
+    background-color: rgba(207, 134, 0, 0.1);
+    border-left: 3px solid #cf8600;
+    padding: 1rem;
+    margin-bottom: 1.5rem;
+    border-radius: 3px;
+}
+
+.op1f-help-text p {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.op1f-tape-mode-section {
+    margin-bottom: 1.5rem;
+}
+
+.op1f-radio-label {
+    display: block;
+    margin-bottom: 1rem;
+    cursor: pointer;
+}
+
+.op1f-file-input-section {
+    display: none;
+    margin-bottom: 1rem;
+}
+
+.op1f-file-input-section.show {
+    display: block;
+}
+
+.op1f-file-label {
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+#tapeJsonFileInput {
+    width: 100%;
+    padding: 0.5rem;
+    box-sizing: border-box;
+}
+
+.op1f-track-section {
+    margin-bottom: 1.5rem;
+}
+
+.op1f-track-label {
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+#op1fTrackSelect {
+    width: 100%;
+    padding: 0.5rem;
+    box-sizing: border-box;
+}
+
+.op1f-button-group {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+}
+
 #welcomePanelMd .tip-header {
     margin-left: 1rem;
 }
@@ -2365,7 +2431,7 @@ dialog .content {
     flex-direction: row;
     justify-content: space-around;
     padding-left: 1rem;
-    width: 14rem;
+    width: 18rem;
 }
 .chain-action-icons button {
     padding: 0;


### PR DESCRIPTION
Adds a OP-1F tape export functionality to DigiChain, allowing users to export selected samples to an OP-1 Field tape track with automatic slice metadata generation.

Features:
- New OP-1F button in preset bundling section (mutually exclusive with TV/XY modes)
- Configuration dialog for creating new or loading existing tape.json files
- Track selection (1-4) for exporting to specific OP-1F tape tracks
- Automatic audio configuration (44.1kHz, stereo, 16-bit) when OP-1F mode is activated
- Joined WAV file generation with no gaps between samples
- Automatic tape.json creation/updating with clip metadata
- ZIP export containing WAV file and updated tape.json
- Proper preservation of clips from other tracks when updating existing tapes
- Help text explaining the feature and warning about track overwrites
- Neutral default mixer parameters for new tapes (0.9 levels, 0.0 pans)